### PR TITLE
refactor ScheduleTime component

### DIFF
--- a/src/components/ScheduleTable.vue
+++ b/src/components/ScheduleTable.vue
@@ -1,11 +1,12 @@
 <template>
   <div class="mb-5">
     <div v-for="(content, idx) in track.content" :key="`content-${idx}`">
-      <ScheduleStartingTime :content="content"/>
+      <ScheduleTime :content="content.startTime"/>
       <b-row class="my-3">
         <ScheduleTimeLine :content="content"/>
         <ScheduleContentBox :content="content"/>
       </b-row>
+      <ScheduleTime v-if="content.endTime" :content="content.endTime"/>
     </div>
   </div>
 </template>
@@ -13,14 +14,14 @@
 <script>
 
 import ScheduleTimeLine from '@/components/ScheduleTimeLine'
-import ScheduleStartingTime from '@/components/ScheduleStartingTime'
+import ScheduleTime from '@/components/ScheduleTime'
 import ScheduleContentBox from '@/components/ScheduleContentBox'
 
 export default {
   name: 'ScheduleTable',
   components: {
     ScheduleContentBox,
-    ScheduleStartingTime,
+    ScheduleTime,
     ScheduleTimeLine
   },
   props: {

--- a/src/components/ScheduleTime.vue
+++ b/src/components/ScheduleTime.vue
@@ -2,7 +2,7 @@
   <div>
     <div class="starting-time">
       <span class="starting-time__start-time font-weight-bold mr-1 text-monospace">
-        {{content.startTime.h}}:{{content.startTime.m}}
+        {{content.h}}:{{content.m}}
       </span>
       <span class="starting-time__circle d-inline-block"/>
     </div>
@@ -11,7 +11,7 @@
 
 <script>
 export default {
-  name: 'ScheduleStartingTime',
+  name: 'ScheduleTime',
   props: {
     content: {}
   }

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -188,7 +188,8 @@ const data = {
         },
         {
           title: 'Networking & Beers online 💃🍻',
-          startTime: { h: '21', m: '30' }
+          startTime: { h: '21', m: '30' },
+          endTime: { h: '21', m: '50' }
         }
       ]
     }


### PR DESCRIPTION
Refactor ScheduleStartingTime component (now ScheduleTime) so it can be used for the ending time of the talks. It currently looks like this:

![image](https://user-images.githubusercontent.com/52920777/96927909-142d8e80-14b8-11eb-931b-ded19295970e.png)

Closed #83 