### PR TITLE
fixed styles on mobile

### DIFF
--- a/src/components/ScheduleTimeLine.vue
+++ b/src/components/ScheduleTimeLine.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-col cols="auto">
+  <b-col cols="1" sm="auto">
     <div class="time-line-bar-container">
       <div class="time-line-bar rounded" />
     </div>

--- a/src/components/SpeakersInfo.vue
+++ b/src/components/SpeakersInfo.vue
@@ -8,7 +8,7 @@
           <b-avatar variant="light" size="2.5rem" src="https://cdn.iconscout.com/icon/free/png-256/laugh-1659498-1410020.png"></b-avatar>
         </div>
         <div>
-          <div class="d-flex align-items-center mb-1">
+          <div class="d-md-flex align-items-center mb-1">
             <h5 class="speaker-name font-weight-bold mb-0"> {{ speaker.name }}</h5>
             <div class="ml-2">
               <TalkAuthorsSocial :social="speaker.social"/>


### PR DESCRIPTION
Fixed some styles on mobile display (provisionally). We might need to rethink the design. It currently looks like this on mobile: 

![image](https://user-images.githubusercontent.com/52920777/97054644-72747300-1585-11eb-974a-a54e36c55db2.png)