### PR TITLE
Add negative margin-bottom to align the event type badge with the date and the title

### DIFF
--- a/src/components/BaseHeader.vue
+++ b/src/components/BaseHeader.vue
@@ -50,6 +50,10 @@ main-blue = #003DA5
 .base-header
   margin-top 60px
 
+  .flex-header-item
+    &:last-child
+      margin-bottom: -15px
+
   .title
     font-size 36px
     font-weight 600


### PR DESCRIPTION
He estado viendo varias alternativas para alinearlo y creo que lo mejor y más simple es esto. Porque luego podías alinear la fecha y no mover el badge pero entonces queda muy raro respecto al título. ¿Que te parece @baumannzone?

![Aligned badge](https://i.gyazo.com/f9de7dc75e8679c7f82755ac0fdb3b58.png)