### PR TITLE
(feature) Habilitar temas

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,13 +9,15 @@
 
 :root
   --color-blue: #003DA5
+  --color-blue-dark: #0c2251
+  --color-white: #ffffff
   --color-main: var(--color-blue)
   --color-secondary: #4875C0
   --color-border: #E1EAFC
   --color-background: #F9FAFC
   --color-background-highlight: #F1F6FF
   --color-background-shadow: #F4F4F4
-  --color-background-light: white
+  --color-background-light: var(--color-white)
   --color-text: #212529
   --color-text-light: #66676f
   --color-text-secondary: #3F414E

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,14 +7,43 @@
 <style lang="stylus">
 @import url('https://fonts.googleapis.com/css2?family=Nunito:wght@700&family=Open+Sans:wght@400;600;700&display=swap');
 
+:root
+  --color-blue: #003DA5
+  --color-main: var(--color-blue)
+  --color-secondary: #4875C0
+  --color-border: #E1EAFC
+  --color-background: #F9FAFC
+  --color-background-highlight: #F1F6FF
+  --color-background-shadow: #F4F4F4
+  --color-background-light: white
+  --color-text: #212529
+  --color-text-light: #66676f
+  --color-text-secondary: #3F414E
+  --color-text-action: #4C77C0
+  --color-icon #c4c4c4
+
+[data-theme="dark"]
+    --color-main: #f4f4f4
+    --color-secondary: #4875C0
+    --color-border: #052154
+    --color-background: #00040d
+    --color-background-highlight: #041940
+    --color-background-shadow: #0c2a73
+    --color-background-light: #050918
+    --color-text: #c4c4c4
+    --color-text-light: #66676f
+    --color-text-secondary: #c4c4c4
+    --color-text-action: #4C77C0
+    --color-icon #052154
+
 body
   margin 0
-  background-color #F9FAFC !important
+  background-color var(--color-background) !important
+  color var(--color-text) !important
 
 #app
    font-family 'Open Sans', sans-serif
   -webkit-font-smoothing antialiased
   -moz-osx-font-smoothing grayscale
-  color #2c3e50
 
 </style>

--- a/src/components/BaseFooter.vue
+++ b/src/components/BaseFooter.vue
@@ -30,13 +30,13 @@ export default {
 
 <style lang="stylus">
 footer
-  background-color white
+  background-color var(--color-background-light)
   height 230px
   padding-top 50px
-  box-shadow 0 0 10px #F4F4F4
+  box-shadow 0 0 10px var(--color-background-shadow);
 
   .blue-text
-    color #4C77C0
+    color var(--color-text-action)
 
   .parrot-img
     display inline-block

--- a/src/components/BaseHeader.vue
+++ b/src/components/BaseHeader.vue
@@ -23,7 +23,7 @@
       </b-row>
       <b-row>
         <b-col lg="4" md="12">
-          <b-button v-if="!isTimeZoneSelectorActive && isUserInMadrid" size="sm" variant="light" @click="isTimeZoneSelectorActive = true">Pincha aquí para cambiar a otra zona horaria</b-button>
+          <b-button class="timezone-button" v-if="!isTimeZoneSelectorActive && isUserInMadrid" size="sm" variant="light" @click="isTimeZoneSelectorActive = true">Pincha aquí para cambiar a otra zona horaria</b-button>
           <TimezoneSelector v-if="isTimeZoneSelectorActive || !isUserInMadrid"/>
         </b-col>
       </b-row>
@@ -79,8 +79,6 @@ export default {
 </script>
 
 <style lang="stylus">
-main-blue = #003DA5
-
 .base-header
   margin-top 60px
 
@@ -91,27 +89,32 @@ main-blue = #003DA5
   .title
     font-size 36px
     font-weight 600
-    color main-blue
+    color var(--color-main)
 
     small.date
       font-size 18px
       font-weight bold
       margin-left 7px
 
-  .meetup-item
-    a
-      &:hover
-        color #f63f60
-        text-decoration none
+.meetup-item
+  a
+    transition color 200ms ease-in
+    &:hover
+      color var(--color-main) !important
+      text-decoration none
 
-  .description-item
-    color #8C8D95
-    font-weight 500
+.description-item
+  color var(--color-text-secondary)
+  font-weight 500
 
 .timezone-disclaimer
   font-size: 14px
 
 .christmas-badge
-  color white
+  color var(--color-background-light)
   background #f00000
+
+.timezone-button
+  background-color var(--color-background-highlight) !important
+  color var(--color-main) !important
 </style>

--- a/src/components/BaseHeader.vue
+++ b/src/components/BaseHeader.vue
@@ -1,18 +1,16 @@
 <template>
   <header class="mb-3">
-    <div class="base-header d-flex justify-content-between align-items-center mb-3 justify-content-md-start">
-      <div class="flex-header-item">
+    <div class="base-header d-flex justify-content-between align-items-center mb-3">
+      <div class="flex-header-item d-flex flex-direction-row">
         <h1 class="title m-0 font-weight-bold">
           {{ headerData.title }}
           <small class="date">
             {{ dateOnSelectedTimezone }}
           </small>
         </h1>
-      </div>
-      <div class="flex-header-item">
         <CBadge class="mr-2 ml-md-2 christmas-badge"> ⛄ Christmas Edition </CBadge>
-        <!--<CBadge class="mr-2 ml-md-2">{{ headerData.eventType }}</CBadge>-->
       </div>
+      <ThemeSwitch />
     </div>
     <!-- Timezone selector -->
     <div class="flex-column justify-start mb-4" v-if="headerData.isTimezoneSelectorEnabled">
@@ -21,7 +19,7 @@
           <p v-if="!isUserInMadrid" class="timezone-disclaimer">Nos han chivado que no estás en España (o al menos en la zona horaria de españa), no te preocupes, cambiamos el horario a tu zona para que nos puedas ver</p>
         </b-col>
       </b-row>
-      <b-row>
+      <b-row align-h="between">
         <b-col lg="4" md="12">
           <b-button class="timezone-button" v-if="!isTimeZoneSelectorActive && isUserInMadrid" size="sm" variant="light" @click="isTimeZoneSelectorActive = true">Pincha aquí para cambiar a otra zona horaria</b-button>
           <TimezoneSelector v-if="isTimeZoneSelectorActive || !isUserInMadrid"/>
@@ -35,7 +33,7 @@
         <div class="mb-0"> {{ headerData.description }}</div>
       </div>
       <div class="meetup-item align-self-start">
-        <a class="text-body" :href="headerData.meetupLink" title="Ver más en meetup" target="_blank">
+        <a class="icon" :href="headerData.meetupLink" title="Ver más en meetup" target="_blank">
           <font-awesome-icon :icon="['fab', 'meetup']" size="2x"/>
         </a>
       </div>
@@ -45,6 +43,7 @@
 
 <script>
 import CBadge from '@/components/CustomBadge'
+import ThemeSwitch from '@/components/ThemeSwitch'
 import TimezoneSelector from '@/components/TimezoneSelector'
 import { mapState } from 'vuex'
 import dayjs from 'dayjs'
@@ -53,7 +52,8 @@ export default {
   name: 'BaseHeader',
   components: {
     TimezoneSelector,
-    CBadge
+    CBadge,
+    ThemeSwitch
   },
   props: {
     headerData: {
@@ -98,6 +98,7 @@ export default {
 
 .meetup-item
   a
+    color var(--color-text)
     transition color 200ms ease-in
     &:hover
       color var(--color-main) !important

--- a/src/components/CustomBadge.vue
+++ b/src/components/CustomBadge.vue
@@ -11,8 +11,8 @@ export default {}
 <style lang="stylus">
 .badge--soft-blue
   display inline-block
-  background-color #F1F6FF
-  color #4875C0
+  background-color var(--color-background-highlight)
+  color var(--color-text-secondary)
   padding  5px 15px
   margin 5px
   border-radius 10px

--- a/src/components/MeetupLink.vue
+++ b/src/components/MeetupLink.vue
@@ -3,7 +3,7 @@
     <div v-if="eventType === 'Online'">
       <p>Síguenos en</p>
       <a class="link mb-3" href="https://www.twitch.tv/osweekends">
-        <div class="icon bg-white rounded-circle d-flex justify-content-center align-items-center mb-3">
+        <div class="icon rounded-circle d-flex justify-content-center align-items-center mb-3">
           <font-awesome-icon :icon="['fab', 'twitch']" size="5x"/>
         </div>
         <span class="address">twitch.tv/osweekends</span>
@@ -13,7 +13,7 @@
     <div v-else>
       <a class="link mb-3"
          href="https://www.google.com/search?sxsrf=ALeKk01W0wUmU-ubU9z2pfgRFZY50MntHw:1602887276901&q=google+campus&npsic=0&rflfq=1&rlha=0&rllag=40412472,-3718242,10&tbm=lcl&ved=2ahUKEwigpYS2lLrsAhWPA2MBHf6JCucQtgN6BAgGEAc&rldoc=1#rlfi=hd:;si:18186252069890377247,l,Cg1nb29nbGUgY2FtcHVzIgOIAQFaHgoNZ29vZ2xlIGNhbXB1cyINZ29vZ2xlIGNhbXB1cw;mv:[[40.4382547,-3.6678058],[40.4109177,-3.7211292]]">
-        <div class="icon bg-white rounded-circle d-flex justify-content-center align-items-center mb-3">
+        <div class="icon rounded-circle d-flex justify-content-center align-items-center mb-3">
           <font-awesome-icon :icon="['fas', 'map-marker-alt']" size="5x"/>
         </div>
         <span class="address">C. de Moreno Nieto, 2, 28005 Madrid</span>
@@ -35,23 +35,25 @@ export default {
 </script>
 
 <style lang="stylus">
-main-blue = #003DA5
 .link
   display inline-block
 
   .icon
-    color #3F414E
+    color var(--color-icon)
     width 200px
     height 200px
     margin auto
 
   .address
-    color #3F414E
+    color var(--color-icon)
     font-size 24px
     font-weight bolder
     text-decoration none
 
   &:hover
-    color #003DA5
+    color var(--color-main)
     text-decoration none
+
+.icon
+  background var(--color-background-light) !important
 </style>

--- a/src/components/ScheduleContentBox.vue
+++ b/src/components/ScheduleContentBox.vue
@@ -44,4 +44,7 @@ export default {
 <style lang="stylus" scoped>
 .content-box
   padding 40px
+
+.bg-white
+  background-color var(--color-background-light) !important
 </style>

--- a/src/components/ScheduleTable/TalkAuthorsSocial.vue
+++ b/src/components/ScheduleTable/TalkAuthorsSocial.vue
@@ -52,7 +52,7 @@ export default {
 <style lang="stylus">
 .ico-link
   font-size 1.3rem
-  color #333
+  color var(--color-text)
 
   //&.ico-twitter
   //  color #059ff6
@@ -76,6 +76,8 @@ export default {
   //  color #2f2f2f
   //&.ico-gamepad
   //  color orange
+  &:hover
+    color var(--color-main)
 
 a.multiple:not(:last-child) {
   margin-right: 0.5rem;

--- a/src/components/ScheduleTime.vue
+++ b/src/components/ScheduleTime.vue
@@ -36,7 +36,7 @@ export default {
 </script>
 
 <style lang="stylus">
-main-blue = #003DA5
+
 .starting-time
   &__time-container
     display flex
@@ -44,13 +44,13 @@ main-blue = #003DA5
     align-items center
 
   &__start-time
-    color main-blue
+    color var(--color-main)
 
   &__circle
     position relative
     width 14px
     height 14px
-    background main-blue
+    background var(--color-blue)
     border-radius 50%
-    border 3.5px solid #C7D4EB
+    border 3.5px solid var(--color-border)
 </style>

--- a/src/components/ScheduleTimeLine.vue
+++ b/src/components/ScheduleTimeLine.vue
@@ -13,8 +13,6 @@ export default {
 </script>
 
 <style lang="stylus" scoped>
-main-blue = #003DA5
-
 .time-line-bar-container
   position relative
   width 71px
@@ -22,7 +20,7 @@ main-blue = #003DA5
 
 .time-line-bar
   width 4px
-  background-color #E1EAFC
+  background-color var(--color-border)
   height 100%
   position absolute
   right 0

--- a/src/components/SpeakersInfo.vue
+++ b/src/components/SpeakersInfo.vue
@@ -47,7 +47,7 @@ export default {
 .speakers
   .speaker-name,
   .social-ico
-    color #3F414E
+    color var(--color-text-secondary)
   .speaker-bio > p
-    color #8C8D95
+    color var(--color-text-light)
 </style>

--- a/src/components/Sponsors.vue
+++ b/src/components/Sponsors.vue
@@ -25,7 +25,7 @@ export default {
 
 <style lang="stylus">
 .sponsors-section
-  color #898B94
+  color var(--color-text-secondary)
 
   .sponsors
     text-align center

--- a/src/components/ThemeSwitch.vue
+++ b/src/components/ThemeSwitch.vue
@@ -1,0 +1,69 @@
+<template>
+    <label class="switch">
+        <input @click="setTheme" type="checkbox" :checked="checked">
+        <span class="slider round"></span>
+    </label>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+
+export default {
+  name: 'ThemeSwitch',
+  computed: {
+    ...mapState({
+      theme: state => state.theme.name }),
+    checked () {
+      console.log('What is the theme? ', this.theme)
+      return this.theme === 'dark'
+    }
+  },
+  methods: {
+    setTheme () {
+      console.log('theme ', this.theme)
+      const newTheme = this.theme === 'light' ? 'dark' : 'light'
+      console.log(newTheme)
+      this.$store.dispatch('theme/setThemeName', newTheme)
+    }
+  }
+}
+</script>
+
+<style lang="stylus">
+.switch
+  position: relative
+  display: inline-block
+  width: 42px
+  height: 28px
+
+  & input
+    opacity: 0
+    width: 0
+    height: 0
+
+.slider
+  position: absolute
+  cursor: pointer
+  top: 0
+  left: 0
+  right: 0
+  bottom: 0
+  background-color: var(--color-blue-dark)
+  transition: all 350ms cubic-bezier(0.8, 1.49, 1, 1)
+  border-radius: 20px
+
+  &:before
+    position: absolute
+    content: ""
+    height: 20px
+    width: 20px
+    left: 4px
+    bottom: 4px
+    background-color: var(--color-white)
+    transition: all 350ms cubic-bezier(0.8, 1.49, 1, 1)
+    border-radius: 50%
+
+    input:checked + &
+      transform: translateX(15px)
+
+</style>

--- a/src/components/TimezoneSelector.vue
+++ b/src/components/TimezoneSelector.vue
@@ -43,3 +43,8 @@ export default {
   }
 }
 </script>
+<style lang="stylus">
+.timezone-selector select
+  background-color var(--color-background-highlight)
+  color var(--color-main)
+</style>

--- a/src/components/TwitchIsLive.vue
+++ b/src/components/TwitchIsLive.vue
@@ -1,13 +1,13 @@
 <template>
   <b-row v-if="isLive" class="mb-5 mb-sm-2">
     <b-col cols="1" sm="auto">
-      <div style="width: 71px" class="bg-primary"></div>
+      <div style="width: 71px"></div>
     </b-col>
     <b-col>
       <a href="https://www.twitch.tv/osweekends" class="text-decoration-none" title="¡OSWeekends está emitiendo!">
         <div class="box-is-live p-5 d-flex flex-column flex-sm-row justify-content-between align-items-center shadow-sm rounded">
           <div>
-            <h3 class="m-0 text-white text-center text-sm-right mb-3 mb-sm-0">
+            <h3 class="m-0 text-center text-sm-right mb-3 mb-sm-0">
               ¡OSWeekends está en directo!
             </h3>
           </div>
@@ -52,12 +52,10 @@ export default {
 </script>
 
 <style lang="stylus">
-twitch-bg = #772ce8
-circle-color = white
-
-.box-is-live {
-  background: twitch-bg
-}
+.box-is-live
+  color var(--color-main)
+  background var(--color-background-highlight)
+  box-shadow 2px 2px var(--color-background-shadow)
 
 .loader {
   animation: pulse 2s infinite ease-out;
@@ -110,7 +108,7 @@ circle-color = white
 .loader {
   width: 20px;
   height: 20px;
-  background: circle-color;
+  background: var(--color-main);
   border-radius: 50%;
 }
 
@@ -119,7 +117,7 @@ circle-color = white
   position: absolute;
   width: 30px;
   height: 30px;
-  border: 0.25em solid circle-color;
+  border: 0.25em solid var(--color-main);
   border-radius: 50%;
 }
 
@@ -128,7 +126,7 @@ circle-color = white
   position: absolute;
   width: 50px;
   height: 50px;
-  border: 0.25em solid circle-color;
+  border: 0.25em solid var(--color-main);
   border-radius: 50%;
   opacity: 0;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -32,6 +32,9 @@ Vue.component('font-awesome-icon', FontAwesomeIcon)
 Vue.use(BootstrapVue)
 Vue.config.productionTip = false
 
+// Initialize data-theme from the Vuex store
+document.documentElement.setAttribute('data-theme', store.state.theme.name)
+
 new Vue({
   router,
   store,

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,11 +1,13 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
 import timezone from './modules/timezone.store'
+import theme from './modules/theme.store'
 
 Vue.use(Vuex)
 
 export default new Vuex.Store({
   modules: {
-    timezone
+    timezone,
+    theme
   }
 })

--- a/src/store/modules/theme.store.js
+++ b/src/store/modules/theme.store.js
@@ -1,0 +1,26 @@
+const state = () => ({
+  // theme is a name, so we potentially could have different palettes
+  name: window.localStorage.getItem('theme') || 'light'
+})
+
+const mutations = {
+  SET_THEME (state, value) {
+    state.name = value
+  }
+}
+
+const actions = {
+  setThemeName ({ commit }, themeName = 'light') {
+    window.localStorage.setItem('theme', themeName)
+    document.documentElement.setAttribute('data-theme', themeName)
+
+    commit('SET_THEME', themeName)
+  }
+}
+
+export default {
+  namespaced: true,
+  state,
+  mutations,
+  actions
+}


### PR DESCRIPTION
Esta PR soluciona/habilita https://github.com/OSWeekends/agenda/issues/100

Cualquier comentario es bienvenida, nunca he programado en Vue asi que seguro que puedo mejorar algo.

Principales cambios introducidos:
- Elemento `:root` ahora contiene CSS variables con colores semánticos. He intentado simplificar o substituir algunos de los colores que no correspondían.
- Añadida la paleta de dark theme.
- Componente `ThemeSwitch` conectado a Vuex para cambiar el theme entre `light` y `dark`
- Persistir theme en `LocalStorage`

Hay cosas que se han hecho algo diferentes por el simple hecho de que el proyecto incluye `Bootstrap-Vue`, pero esto esta fuera de scope para este cambio. 

No conozco todos los casos / variaciones de la web, asi que hay que comprobar que el dark theme cubre esos casos